### PR TITLE
Node provisioner refactor

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,7 +81,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>crypto-util</artifactId>
-      <version>1.1</version>
+      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson</groupId>

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -372,7 +372,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     public Api getApi() {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.SYSTEM_READ);
         return new Api(this);
     }
 
@@ -1704,7 +1704,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     @Restricted(NoExternalUse.class)
     @RequirePOST public HttpResponse doCheckUpdatesServer() throws IOException {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.SYSTEM_READ);
 
         // We'll check the update servers with a try-retry mechanism. The retrier is built with a builder
         Retrier<FormValidation> updateServerRetrier = new Retrier.Builder<>(
@@ -2241,7 +2241,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @Restricted(NoExternalUse.class)
     public Object getTarget() {
         if (!SKIP_PERMISSION_CHECK) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.SYSTEM_READ);
         }
         return this;
     }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -385,6 +385,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      */
     @Restricted(DoNotUse.class)
     public HttpResponse doConnectionStatus(StaplerRequest request) {
+        Jenkins.get().checkPermission(Jenkins.SYSTEM_READ);
         try {
             String siteId = request.getParameter("siteId");
             if (siteId == null) {
@@ -699,6 +700,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      */
     @RequirePOST
     public void doUpgrade(StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         HudsonUpgradeJob job = new HudsonUpgradeJob(getCoreSource(), Jenkins.getAuthentication());
         if(!Lifecycle.get().canRewriteHudsonWar()) {
             sendError("Jenkins upgrade not supported in this running mode");
@@ -730,6 +732,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      */
     @RequirePOST
     public void doSafeRestart(StaplerRequest request, StaplerResponse response) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         synchronized (jobs) {
             if (!isRestartScheduled()) {
                 addJob(new RestartJenkinsJob(getCoreSource()));
@@ -744,6 +747,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      */
     @RequirePOST
     public void doCancelRestart(StaplerResponse response) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         synchronized (jobs) {
             for (UpdateCenterJob job : jobs) {
                 if (job instanceof RestartJenkinsJob) {
@@ -802,6 +806,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      */
     @RequirePOST
     public void doDowngrade(StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         if(!isDowngradable()) {
             sendError("Jenkins downgrade is not possible, probably backup does not exist");
             return;
@@ -818,6 +823,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      */
     @RequirePOST
     public void doRestart(StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         HudsonDowngradeJob job = new HudsonDowngradeJob(getCoreSource(), Jenkins.getAuthentication());
         LOGGER.info("Scheduling the core downgrade");
 
@@ -2531,7 +2537,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     @Restricted(NoExternalUse.class)
     public Object getTarget() {
         if (!SKIP_PERMISSION_CHECK) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.SYSTEM_READ);
         }
         return this;
     }

--- a/core/src/main/java/jenkins/management/PluginsLink.java
+++ b/core/src/main/java/jenkins/management/PluginsLink.java
@@ -26,6 +26,8 @@ package jenkins.management;
 
 import hudson.Extension;
 import hudson.model.ManagementLink;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -55,6 +57,12 @@ public class PluginsLink extends ManagementLink {
         return "pluginManager";
     }
 
+    @NonNull
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.SYSTEM_READ;
+    }
+  
     @NonNull
     @Override
     public Category getCategory() {

--- a/core/src/main/resources/hudson/PluginManager/_api.jelly
+++ b/core/src/main/resources/hudson/PluginManager/_api.jelly
@@ -25,11 +25,13 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <h2>Uploading a plugin</h2>
+  <p>Permission required: <code>Overall/Administer</code></p>
   <p>
     You can upload a plugin from HTTP client by POST to <a href="../uploadPlugin">this URL</a> with <a href="http://tools.ietf.org/html/rfc2388">multipart/form-data</a> MIME type.
   </p>
 
   <h2>Making sure all the needed plugins are installed</h2>
+  <p>Permission required: <code>Overall/Administer</code></p>
   <p>
     Jenkins uses an XML format for representing most of complex objects internally (such as agents, views, jobs, and builds.)
     As such, it has various APIs that send/receive those XMLs. For example, you can create a new job by POSTing its XML representation.

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -28,7 +28,15 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:layout title="${%Update Center}" permission="${app.ADMINISTER}">
+    <l:layout title="${%Update Center}" permission="${app.SYSTEM_READ}">
+      <j:choose>
+        <j:when test="${app.hasPermission(app.ADMINISTER)}">
+          <j:set var="readOnlyMode" value="false" />
+        </j:when>
+        <j:otherwise>
+          <j:set var="readOnlyMode" value="true" />
+        </j:otherwise>
+      </j:choose>
         <st:include page="sidepanel.jelly"/>
         <l:main-panel>
             <local:tabBar page="advanced" xmlns:local="/hudson/PluginManager"/>
@@ -42,12 +50,15 @@ THE SOFTWARE.
                                 <j:set var="descriptor" value="${it.proxyDescriptor}"/>
                                 <st:include from="${descriptor}" page="${descriptor.configPage}"/>
                             </j:scope>
+                          <l:isAdmin>
                             <f:block>
                                 <f:submit/>
                             </f:block>
+                          </l:isAdmin>
                         </f:form>
                     </section>
 
+                  <l:isAdmin>
                     <section>
                         <h2>${%Upload Plugin}</h2>
                         <f:form method="post" action="uploadPlugin" name="uploadPlugin" enctype="multipart/form-data">
@@ -66,6 +77,7 @@ THE SOFTWARE.
                             </f:block>
                         </f:form>
                     </section>
+                  </l:isAdmin>
 
                     <section>
                         <h2>${%Update Site}</h2>
@@ -74,9 +86,11 @@ THE SOFTWARE.
                                 <f:textbox name="site"
                                            value="${app.updateCenter.getSite(app.updateCenter.ID_DEFAULT).url}"/>
                             </f:entry>
+                          <l:isAdmin>
                             <f:block>
                                 <f:submit/>
                             </f:block>
+                          </l:isAdmin>
                         </f:form>
                         <j:set var="hasNonDefault" value="${false}"/>
                         <j:forEach var="site" items="${app.updateCenter.sites}">

--- a/core/src/main/resources/hudson/PluginManager/index.jelly
+++ b/core/src/main/resources/hudson/PluginManager/index.jelly
@@ -29,9 +29,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:table page="updates" list="${app.updateCenter.updates}" xmlns:local="/hudson/PluginManager">
     <div style="margin-top:1em">
+      <l:isAdmin>
       ${%Select}: <a href="javascript:toggleCheckboxes(true);">${%All}</a>,
                   <a href="javascript:checkPluginsWithoutWarnings();">${%Compatible}</a>,
                   <a href="javascript:toggleCheckboxes(false);">${%None}</a><br/>
+      </l:isAdmin>
       ${%UpdatePageDescription}
       <j:if test="${!empty(app.updateCenter.jobs)}">
         <br/> ${%UpdatePageLegend(rootURL+'/updateCenter/')}

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -27,7 +27,15 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:layout title="${%Update Center}" permission="${app.ADMINISTER}">
+  <l:layout title="${%Update Center}" permission="${app.SYSTEM_READ}">
+    <j:choose>
+      <j:when test="${app.hasPermission(app.ADMINISTER)}">
+        <j:set var="readOnlyMode" value="false" />
+      </j:when>
+      <j:otherwise>
+        <j:set var="readOnlyMode" value="true" />
+      </j:otherwise>
+    </j:choose>
     <st:include page="sidepanel.jelly"/>
     <l:main-panel>
         <st:adjunct includes="hudson.PluginManager._table"/>
@@ -66,8 +74,10 @@ THE SOFTWARE.
                 <th width="32" tooltip="${%Uncheck to disable the plugin}">${%Enabled}</th>
                 <th initialSortDir="down">${%Name}</th>
                 <th width="1">${%Version}</th>
-                <th width="1">${%Previously installed version}</th>
-                <th width="1">${%Uninstall}</th>
+                <l:isAdmin>
+                  <th width="1">${%Previously installed version}</th>
+                  <th width="1">${%Uninstall}</th>
+                </l:isAdmin>
               </tr>
               <j:forEach var="p" items="${app.pluginManager.plugins}">
                 <tr class="plugin ${p.hasMandatoryDependents()?'has-dependents':''} ${(p.hasMandatoryDependents() and !p.enabled)?'has-dependents-but-disabled':''} ${p.isDeleted()?'deleted':''} ${p.hasImpliedDependents() and p.enabled ? 'possibly-has-implied-dependents' : ''}" data-plugin-id="${p.shortName}" data-plugin-name="${p.displayName}">
@@ -75,6 +85,7 @@ THE SOFTWARE.
                   <td class="center pane enable" data="${state}">
                     <input type="checkbox" checked="${state}" onclick="flip(event)"
                            url="plugin/${p.shortName}"
+                           disabled="${readOnlyMode ? 'true' : null}"
                            original="${p.active?'true':'false'}"/>
                   </td>
                   <td class="pane details">
@@ -122,47 +133,49 @@ THE SOFTWARE.
                       ${p.version}
                     </a>
                   </td>
-                  <td class="pane">
-                    <j:if test="${p.downgradable}">
-                      <form method="post" action="${rootURL}/updateCenter/plugin/${p.shortName}/downgrade">
-                        <s:submit value="${%downgradeTo(p.backupVersion)}"/>
-                      </form>
-                    </j:if>
-                  </td>
-                  <j:choose>
-                      <j:when test="${p.hasMandatoryDependents() or p.hasMandatoryDependents()}">
-                            <j:set var="uninstallPossible" value="true"/>
-                      </j:when>
-                      <j:otherwise>
-                          <j:set var="uninstallPossible" value="false"/>
-                      </j:otherwise>
-                  </j:choose>
-                  <td class="center pane uninstall" data="${uninstallPossible}">
+                  <l:isAdmin>
+                    <td class="pane">
+                      <j:if test="${p.downgradable}">
+                        <form method="post" action="${rootURL}/updateCenter/plugin/${p.shortName}/downgrade">
+                          <s:submit value="${%downgradeTo(p.backupVersion)}"/>
+                        </form>
+                      </j:if>
+                    </td>
                     <j:choose>
-                      <j:when test="${p.isDeleted()}">
-                        <p>${%Uninstallation pending}</p>
-                      </j:when>
-                      <j:otherwise>
-                          <j:if test="${p.hasMandatoryDependents()}">
-                            <div class="dependent-list">
-                              <j:forEach var="dependent" items="${p.mandatoryDependents}">
-                                <span data-plugin-id="${dependent}"></span>
-                              </j:forEach>
-                            </div>
-                          </j:if>
-                          <j:if test="${p.hasMandatoryDependencies()}">
-                            <div class="dependency-list">
-                              <j:forEach var="dependency" items="${p.mandatoryDependencies}">
-                                <span data-plugin-id="${dependency.shortName}"></span>  
-                              </j:forEach>
-                            </div>
-                          </j:if>
-                          <form method="post" action="plugin/${p.shortName}/uninstall">
-                              <input class="uninstall" type="submit" value="${%Uninstall}"/>
-                          </form>
-                      </j:otherwise>
+                        <j:when test="${p.hasMandatoryDependents() or p.hasMandatoryDependents()}">
+                              <j:set var="uninstallPossible" value="true"/>
+                        </j:when>
+                        <j:otherwise>
+                            <j:set var="uninstallPossible" value="false"/>
+                        </j:otherwise>
                     </j:choose>
-                  </td>
+                    <td class="center pane uninstall" data="${uninstallPossible}">
+                      <j:choose>
+                        <j:when test="${p.isDeleted()}">
+                          <p>${%Uninstallation pending}</p>
+                        </j:when>
+                        <j:otherwise>
+                            <j:if test="${p.hasMandatoryDependents()}">
+                              <div class="dependent-list">
+                                <j:forEach var="dependent" items="${p.mandatoryDependents}">
+                                  <span data-plugin-id="${dependent}"></span>
+                                </j:forEach>
+                              </div>
+                            </j:if>
+                            <j:if test="${p.hasMandatoryDependencies()}">
+                              <div class="dependency-list">
+                                <j:forEach var="dependency" items="${p.mandatoryDependencies}">
+                                  <span data-plugin-id="${dependency.shortName}"></span>
+                                </j:forEach>
+                              </div>
+                            </j:if>
+                            <form method="post" action="plugin/${p.shortName}/uninstall">
+                                <input class="uninstall" type="submit" value="${%Uninstall}"/>
+                            </form>
+                        </j:otherwise>
+                      </j:choose>
+                    </td>
+                  </l:isAdmin>
                 </tr>
               </j:forEach>
               <!-- failed ones -->

--- a/core/src/main/resources/hudson/PluginManager/sidepanel.groovy
+++ b/core/src/main/resources/hudson/PluginManager/sidepanel.groovy
@@ -28,7 +28,7 @@ l.header()
 l.side_panel {
     l.tasks {
         l.task(icon:"icon-up icon-md", href:rootURL+'/', title:_("Back to Dashboard"))
-        l.task(icon:"icon-gear2 icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"), permission:app.MANAGE, it:app)
+        l.task(icon:"icon-gear2 icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"))
         if (!app.updateCenter.jobs.isEmpty()) {
             l.task(icon:"icon-plugin icon-md", href:"${rootURL}/updateCenter/", title:_("Update Center"))
         }

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${%Update Center}" permission="${app.ADMINISTER}">
+  <l:layout title="${%Update Center}" permission="${app.SYSTEM_READ}">
     <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <st:adjunct includes="hudson.PluginManager._table"/>
@@ -47,9 +47,11 @@ THE SOFTWARE.
         <div class="pane-frame">
           <table id="plugins" class="sortable pane bigtable stripped-odd">
             <tr>
-              <th initialSortDir="${isUpdates?null:'down'}"
-                  tooltip="${%Check to install the plugin}"
-                  width="32">${%Install}</th>
+              <l:isAdmin>
+                <th initialSortDir="${isUpdates?null:'down'}"
+                    tooltip="${%Check to install the plugin}"
+                    width="32">${%Install}</th>
+              </l:isAdmin>
               <th initialSortDir="${isUpdates?'down':null}">${%Name}</th>
               <th>${%Version}</th>
               <th>${%Released}</th>
@@ -63,12 +65,15 @@ THE SOFTWARE.
                   <j:set var="installedOk"
                          value="${installJob.status.success and installJob.plugin.version==p.version}" />
                   <tr class="${installJob!=null ? 'already-upgraded' : ''} plugin" name="${p.displayName}">
-                    <td class="pane" align="center">
-                      <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
-                             checked="${installedOk ? 'checked' : null}"
-                             disabled="${installedOk ? 'disabled' : null}"
-                             data-compat-warning="${!p.isCompatible(cache)}" />
-                    </td>
+                    <l:isAdmin>
+                      <td class="pane" align="center">
+                        <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
+                               checked="${installedOk ? 'checked' : null}"
+                               disabled="${installedOk ? 'disabled' : null}"
+                               data-compat-warning="${!p.isCompatible(cache)}" />
+                      </td>
+                    </l:isAdmin>
+
                     <td class="pane" data="${h.xmlEscape(p.displayName)}" data-id="${h.xmlEscape(p.name+':'+p.version)}">
                       <div>
                         <a href="${p.wiki}" target="_blank"><st:out value="${p.displayName}"/></a>
@@ -176,13 +181,15 @@ THE SOFTWARE.
 
         <div id="bottom-sticker" >
           <div class="bottom-sticker-inner">
-            <j:if test="${!empty(list)}">
-              <j:if test="${!isUpdates}">
-                <f:submit value="${%Install without restart}" name="dynamicLoad" />
-                <span style="margin-left:2em;"></span>
+            <l:isAdmin>
+              <j:if test="${!empty(list)}">
+                <j:if test="${!isUpdates}">
+                  <f:submit value="${%Install without restart}" name="dynamicLoad" />
+                  <span style="margin-left:2em;"></span>
+                </j:if>
+                <f:submit value="${%Download now and install after restart}" />
               </j:if>
-              <f:submit value="${%Download now and install after restart}" />
-            </j:if>
+            </l:isAdmin>
             <st:include page="check.jelly"/>
             </div>
           </div>

--- a/core/src/main/resources/hudson/ProxyConfiguration/config.groovy
+++ b/core/src/main/resources/hudson/ProxyConfiguration/config.groovy
@@ -1,6 +1,11 @@
 package hudson.ProxyConfiguration
 
 def f=namespace(lib.FormTagLib)
+def l=namespace(lib.LayoutTagLib)
+
+if (!h.hasPermission(app.ADMINISTER)) {
+    set("readOnlyMode", "true")
+}
 
 f.entry(title:_("Server"),field:"name") {
     f.textbox()
@@ -17,10 +22,13 @@ f.entry(title:_("Password"),field:"secretPassword") {
 f.entry(title:_("No Proxy Host"),field:"noProxyHost") {
     f.textarea()
 }
-f.advanced(){
-    f.entry(title:_("Test URL"),field:"testUrl") {
-        f.textbox()
+
+l.isAdmin() {
+    f.advanced() {
+        f.entry(title: _("Test URL"), field: "testUrl") {
+            f.textbox()
+        }
+        f.validateButton(title:_("Validate Proxy"),
+                         method:"validateProxy", with:"testUrl,name,port,userName,secretPassword,noProxyHost")
     }
-    f.validateButton(title:_("Validate Proxy"), 
-                     method:"validateProxy", with:"testUrl,name,port,userName,secretPassword,noProxyHost")
 }

--- a/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
@@ -42,25 +42,27 @@ THE SOFTWARE.
           <a href="${rootURL}/">${%Go back to the top page}</a> <br/>
           (${%you can start using the installed plugins right away}) <!-- leave this text in for a while until users are retrained to expect plugins to work right away without restart -->
         </p>
-        <div class="grey-anime-preload" style="display:none">
-          <l:icon class="icon-grey-anime icon-md"/>
-          <l:icon class="icon-blue icon-md"/>
-          <l:icon class="icon-red icon-md"/>
-          <l:icon class="icon-grey icon-md"/>
-        </div>
-        <p class="info" style="font-weight: normal">
-          <j:if test="${app.lifecycle.canRestart()}">
-            <j:if test="${app.isQuietingDown() or it.isRestartScheduled()}">
-              <input id="scheduleRestartCheckbox" onchange="submitScheduleForm(this)" type="checkbox" checked="checked" />
+        <l:isAdmin>
+          <div class="grey-anime-preload" style="display:none">
+            <l:icon class="icon-grey-anime icon-md"/>
+            <l:icon class="icon-blue icon-md"/>
+            <l:icon class="icon-red icon-md"/>
+            <l:icon class="icon-grey icon-md"/>
+          </div>
+          <p class="info" style="font-weight: normal">
+            <j:if test="${app.lifecycle.canRestart()}">
+              <j:if test="${app.isQuietingDown() or it.isRestartScheduled()}">
+                <input id="scheduleRestartCheckbox" onchange="submitScheduleForm(this)" type="checkbox" checked="checked" />
+              </j:if>
+              <j:if test="${!app.isQuietingDown() and !it.isRestartScheduled()}">
+                <input id="scheduleRestartCheckbox" onchange="submitScheduleForm(this)" type="checkbox" />
+              </j:if>
             </j:if>
-            <j:if test="${!app.isQuietingDown() and !it.isRestartScheduled()}">
-              <input id="scheduleRestartCheckbox" onchange="submitScheduleForm(this)" type="checkbox" />
-            </j:if>
-          </j:if>
-          <label for="scheduleRestartCheckbox">
-            ${%warning}
-          </label>
-        </p>
+            <label for="scheduleRestartCheckbox">
+              ${%warning}
+            </label>
+          </p>
+        </l:isAdmin>
       </form>
     </div>
   </l:ajax>

--- a/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout title="${%Update Center}" permission="${app.ADMINISTER}">
+<l:layout title="${%Update Center}" permission="${app.SYSTEM_READ}">
   <st:include page="sidepanel.jelly" />
   <l:main-panel>
     <h1>${%Installing Plugins/Upgrades}</h1>

--- a/core/src/main/resources/hudson/model/UpdateCenter/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/sidepanel.jelly
@@ -31,10 +31,8 @@ THE SOFTWARE.
   <l:side-panel>
     <l:tasks>
       <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
-      <l:isAdmin>
-        <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" title="${%Manage Jenkins}"/>
-        <l:task href="${rootURL}/pluginManager/" icon="icon-plugin icon-lg" title="${%Manage Plugins}"/>
-      </l:isAdmin>
+      <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" title="${%Manage Jenkins}"/>
+      <l:task href="${rootURL}/pluginManager/" icon="icon-plugin icon-lg" title="${%Manage Plugins}"/>
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -385,6 +385,11 @@ pre.console {
   font-size: @font-size-xs;
 }
 
+.jenkins-not-applicable {
+  color: darkgrey;
+  font-style: italic;
+}
+
 #jenkins .task-link {
     text-decoration: none;
 }


### PR DESCRIPTION
The following refactor is a part of a project for the course UVic SENG 371 Spring.

The refactoring was done in the update() method of the NodeProvisioner.java class. After analyzing the file in multiple static code analyzers namely Better Code Hub and Codacy, it was found that this method was overly long and complex. In order to overcome this, parts of the method were refactored using Extract Method, Split Loop and Extract Variable.
This was done in such a way so as to not reduce the overall readability. The try-catch-finally set of statements were left as is, however two segments of code were which accomplished broad tasks were extracted into methods of their own namely, updateProvsioningState() and updateStrategy() which reduced the overall method size and enhanced readability.
Furthermore, several other trivial refactoring techniques were applied as can be seen in the file.